### PR TITLE
New tests and benchmarks

### DIFF
--- a/httphmac/message.go
+++ b/httphmac/message.go
@@ -8,7 +8,6 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/hex"
-	"errors"
 	"hash"
 	"io"
 	"net/http"
@@ -84,17 +83,6 @@ func (m *Message) Bytes() []byte {
 	b.WriteString(m.Resource.RequestURI())
 
 	return b.Bytes()
-}
-
-func XorBytes(a []byte, b []byte) ([]byte, error) {
-	if len(a) != len(b) {
-		return []byte{}, errors.New("Not matching length.")
-	}
-	ret := []byte{}
-	for i := 0; i < len(a); i++ {
-		ret = append(ret, a[i] ^ b[i])
-	}
-	return ret, nil
 }
 
 // Sign returns the HMAC signature.

--- a/httphmac/message.go
+++ b/httphmac/message.go
@@ -51,12 +51,15 @@ func NewMessage(r *http.Request, headers ...[]string) *Message {
 		}
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return nil
+	var body []byte = []byte{}
+	if r.Body != nil {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil
+		}
+		r.Body.Close()
+		r.Body = ioutil.NopCloser(bytes.NewReader(body))
 	}
-	r.Body.Close()
-	r.Body = ioutil.NopCloser(bytes.NewReader(body))
 
 	return &Message{
 		r.Method,

--- a/httphmac/message.go
+++ b/httphmac/message.go
@@ -15,18 +15,6 @@ import (
 	"strings"
 )
 
-type SubstituteReader struct {
-	reader *bytes.Reader
-}
-
-func (s SubstituteReader) Read(p []byte) (n int, err error) {
-	return s.reader.Read(p)
-}
-
-func (s SubstituteReader) Close() error {
-	return nil
-}
-
 // A Message represents the parts of the HTTP request used in the generation of
 // the HMAC signature.
 type Message struct {
@@ -67,7 +55,8 @@ func NewMessage(r *http.Request, headers ...[]string) *Message {
 	if err != nil {
 		return nil
 	}
-	r.Body = SubstituteReader{bytes.NewReader(body)}
+	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewReader(body))
 
 	return &Message{
 		r.Method,

--- a/httphmac/message_test.go
+++ b/httphmac/message_test.go
@@ -1,8 +1,11 @@
 package httphmac
 
 import (
+	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
 	"net/url"
 	"testing"
 )
@@ -14,7 +17,7 @@ func NewTestMessage() *Message {
 	r, _ := url.Parse("http://example.com/resource/1?key=value")
 
 	return &Message{
-		Method:        "get",
+		Method:        "post",
 		BodyHash:      "9473fdd0d880a43c21b7778d34872157", // MD5 of "test content"
 		ContentType:   "text/plain",
 		Date:          "Fri, 19 Mar 1982 00:00:04 GMT",
@@ -23,11 +26,72 @@ func NewTestMessage() *Message {
 	}
 }
 
+func NewTestLongText() string {
+	return "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque scelerisque convallis dapibus. Phasellus ac rhoncus felis, sit amet lacinia justo. Cras at urna ut augue mollis porttitor. Duis ut vehicula orci. Nulla ex justo, lobortis at neque et, dapibus bibendum nunc. Vivamus porttitor convallis nulla, in sodales augue ullamcorper vel. Nunc ultricies est eu tincidunt luctus. Maecenas ac libero luctus, faucibus quam vitae, placerat purus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aenean bibendum dui a nunc scelerisque ornare. Sed rhoncus mi finibus arcu dapibus, eu mattis ex fringilla. Cras molestie aliquam mi a tincidunt. Integer commodo dictum consectetur. Suspendisse enim velit, porta quis semper ac, condimentum sed ligula. Nulla scelerisque consequat metus faucibus tempus. Cras eros est, bibendum et felis sed, placerat facilisis arcu. Phasellus elit dolor, dictum nec ex sit amet, hendrerit maximus turpis. Quisque eget erat non nunc bibendum ultricies. Phasellus ante ipsum, lobortis at dictum sed, tincidunt nec lorem. Donec venenatis est vitae dui euismod, sed iaculis erat ultrices. Nullam eget metus placerat metus dignissim sodales. Quisque commodo non sem vitae tristique. Integer blandit nunc massa, non cursus massa aliquet sed. Suspendisse urna ipsum, tempus at dapibus vel, venenatis id risus. Etiam commodo fringilla mi, vel molestie augue. Phasellus pretium mollis purus. Duis sollicitudin ac elit id pulvinar. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Morbi imperdiet tincidunt tortor, at ullamcorper tellus sodales ut. Nulla facilisi. Proin ac fringilla arcu. Suspendisse cursus diam nunc, ac malesuada lectus finibus quis. Suspendisse ut ex diam. In hac habitasse platea dictumst. Praesent vitae enim a ante pharetra varius ac ut mauris. Nulla odio nulla, scelerisque nec sollicitudin id, porta ut felis. In auctor imperdiet felis sed finibus. Ut nibh quam, iaculis finibus scelerisque sed, vestibulum ut justo. Fusce lacinia, velit a feugiat gravida, sapien leo tempus nibh, quis ultrices sem arcu convallis arcu. Cras eu odio elit. Sed in porta felis. Sed non lectus et libero aliquet imperdiet eu ut tortor."
+}
+
+func NewTestRequest() *http.Request {
+	req, _ := http.NewRequest("get", "http://example.com/resource/1?key=value",  nil)
+	return req
+}
+
 func TestSign(t *testing.T) {
 	m := NewTestMessage()
 	s := m.Sign(sha1.New, "secret-key")
-	if s != "0Qub9svYlxjAr8OO7N0/3u0sohs=" {
+	if s != "QRMtvnGmlP1YbaTwpWyB/6A8dRU=" {
 		t.Fail()
+	}
+}
+
+func TestSignRequest(t *testing.T) {
+	req := NewTestRequest()
+	m := NewMessage(req)
+	s := m.Sign(sha1.New, "secret-key")
+	if s != "7Tq3+JP3lAu4FoJz81XEx5+qfOc=" {
+		t.Fail()
+	}
+}
+
+func BenchmarkSignSha1LongText(b *testing.B) {
+	t := NewTestLongText()
+	m := NewTestMessage()
+	m.BodyHash = t
+	d := sha1.New
+	for i := 0; i < b.N; i++ {
+		m.Sign(d, "secret-key")
+	}
+}
+
+func BenchmarkSignSha256LongTextMD5(b *testing.B) {
+	t := NewTestLongText()
+	m := NewTestMessage()
+	m.BodyHash = t
+	d := sha256.New
+	for i := 0; i < b.N; i++ {
+		m.Sign(d, "secret-key")
+	}
+}
+
+func BenchmarkSignSha1LongTextMD5(b *testing.B) {
+	t := NewTestLongText()
+	m := NewTestMessage()
+	d := sha1.New
+	for i := 0; i < b.N; i++ {
+		md5s := md5.Sum([]byte(t))
+		m.BodyHash = hex.EncodeToString(md5s[:])
+		m.Sign(d, "secret-key")
+	}
+}
+
+func BenchmarkSignSha256LongText(b *testing.B) {
+	t := NewTestLongText()
+	m := NewTestMessage()
+	m.BodyHash = t
+	d := sha256.New
+	for i := 0; i < b.N; i++ {
+		md5s := md5.Sum([]byte(t))
+		m.BodyHash = hex.EncodeToString(md5s[:])
+		m.Sign(d, "secret-key")
 	}
 }
 

--- a/httphmac/message_test.go
+++ b/httphmac/message_test.go
@@ -62,7 +62,7 @@ func BenchmarkSignSha1LongText(b *testing.B) {
 	}
 }
 
-func BenchmarkSignSha256LongTextMD5(b *testing.B) {
+func BenchmarkSignSha256LongText(b *testing.B) {
 	t := NewTestLongText()
 	m := NewTestMessage()
 	m.BodyHash = t
@@ -83,7 +83,7 @@ func BenchmarkSignSha1LongTextMD5(b *testing.B) {
 	}
 }
 
-func BenchmarkSignSha256LongText(b *testing.B) {
+func BenchmarkSignSha256LongTextMD5(b *testing.B) {
 	t := NewTestLongText()
 	m := NewTestMessage()
 	m.BodyHash = t
@@ -94,6 +94,8 @@ func BenchmarkSignSha256LongText(b *testing.B) {
 		m.Sign(d, "secret-key")
 	}
 }
+
+
 
 func BenchmarkSignSha1(b *testing.B) {
 	m := NewTestMessage()

--- a/httphmac/message_test.go
+++ b/httphmac/message_test.go
@@ -95,8 +95,6 @@ func BenchmarkSignSha256LongTextMD5(b *testing.B) {
 	}
 }
 
-
-
 func BenchmarkSignSha1(b *testing.B) {
 	m := NewTestMessage()
 	d := sha1.New


### PR DESCRIPTION
I corrected the GET test to POST. I also added a test for GET, created right out of a request.
Finally, I added benchmarks for hashing plaintext body and hashing body to MD5 first for both SHA-256 and SHA-1. It would appear that it's less than half as fast. I don't think this is significant enough to justify MD5.
