### PR TITLE
Add port to signable when behind ELB/Proxy

### DIFF
--- a/signers/v2/v2.go
+++ b/signers/v2/v2.go
@@ -105,6 +105,12 @@ func (v *V2Signer) CreateSignable(req *http.Request, authHeaders map[string]stri
 	// The (lowercase) hostname, matching the HTTP "Host" request header field
 	// (including any port number).
 	b.WriteString(req.Host)
+
+	// If behind an ELB/Proxy, the port may not be included in the host field
+	if req.Header.Get("X-Forwarded-Port") != "" {
+		b.WriteString(":")
+		b.WriteString(req.Header.Get("X-Forwarded-Port"))
+	}
 	b.WriteString("\n")
 
 	// The HTTP request path with leading slash, e.g. /resource/11


### PR DESCRIPTION
In some situations (Some load balancers and proxies), the port is not included in the host field, but it is included in a header.  
