### PR TITLE
Revert "Add port to signable when behind ELB/Proxy"

### DIFF
--- a/signers/v2/v2.go
+++ b/signers/v2/v2.go
@@ -105,12 +105,6 @@ func (v *V2Signer) CreateSignable(req *http.Request, authHeaders map[string]stri
 	// The (lowercase) hostname, matching the HTTP "Host" request header field
 	// (including any port number).
 	b.WriteString(req.Host)
-
-	// If behind an ELB/Proxy, the port may not be included in the host field
-	if req.Header.Get("X-Forwarded-Port") != "" {
-		b.WriteString(":")
-		b.WriteString(req.Header.Get("X-Forwarded-Port"))
-	}
 	b.WriteString("\n")
 
 	// The HTTP request path with leading slash, e.g. /resource/11


### PR DESCRIPTION
This reverts commit 0943fc344c63072bd028246a68d8c033611e2471.

I had misunderstood why I was seeing auth failures when I committed  0943fc344c63072bd028246a68d8c033611e2471.  It turns out that ELBs do not modify the host header, and the port is passed through in the host header if the client sent one.  The tricky part to remember is that _most_ clients will strip port 80 for http requests and 443 for https requests, even if you explicitly add them in the URL, for example this will result in a host header without a port:
`curl http://www.example.com:80`

When signing requests, if you specify one of these standard ports, then calculate the signature, and then your client strips the port from the host header, auth will fail.  This was the scenario I ran into and blamed the ELB for.
